### PR TITLE
feat(app): フォルダ監視による自動再解析

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -123,6 +123,33 @@ button:disabled {
   color: #94a3b8;
 }
 
+.watch-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #1e3a2f;
+  color: #4ade80;
+  border: 1px solid #166534;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  padding: 2px 10px;
+}
+
+.watch-badge::before {
+  content: '';
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: #4ade80;
+  border-radius: 50%;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
 .reset-btn {
   background: #334155;
   font-size: 0.8rem;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { FilePicker } from './components/FilePicker'
 import { StatsCards } from './components/StatsCards'
 import { TopPaths } from './components/TopPaths'
 import { StatusChart } from './components/StatusChart'
 import { useDuckDB } from './hooks/useDuckDB'
+import { useDirectoryWatch } from './hooks/useDirectoryWatch'
 import './App.css'
 
 const STATUS_LABEL: Record<string, string> = {
@@ -18,11 +19,19 @@ const STATUS_LABEL: Record<string, string> = {
 export default function App() {
   const { status, stats, error, rowCount, analyze } = useDuckDB()
   const [fileNames, setFileNames] = useState<string[]>([])
+  const [watchDirHandle, setWatchDirHandle] = useState<FileSystemDirectoryHandle | null>(null)
 
   function handleLoad(texts: string[], names: string[]) {
     setFileNames(names)
     analyze(texts)
   }
+
+  const handleNewFiles = useCallback((texts: string[], names: string[]) => {
+    setFileNames((prev) => [...new Set([...prev, ...names])])
+    analyze(texts)
+  }, [analyze])
+
+  useDirectoryWatch(watchDirHandle, handleNewFiles)
 
   return (
     <div className="app">
@@ -34,7 +43,7 @@ export default function App() {
       <main className="app-main">
         {status === 'idle' || status === 'error' ? (
           <div className="landing">
-            <FilePicker onLoad={handleLoad} disabled={false} />
+            <FilePicker onLoad={handleLoad} onWatchDir={setWatchDirHandle} disabled={false} />
             {error && <p className="error-msg">{error}</p>}
           </div>
         ) : status === 'done' ? (
@@ -42,7 +51,10 @@ export default function App() {
             <div className="dashboard-meta">
               <span>{fileNames.join(', ')}</span>
               <span>{rowCount.toLocaleString()} 件</span>
-              <button className="reset-btn" onClick={() => { setFileNames([]); window.location.reload() }}>
+              {watchDirHandle && (
+                <span className="watch-badge">監視中（10秒ごと）</span>
+              )}
+              <button className="reset-btn" onClick={() => { setFileNames([]); setWatchDirHandle(null); window.location.reload() }}>
                 リセット
               </button>
             </div>

--- a/app/src/components/FilePicker.tsx
+++ b/app/src/components/FilePicker.tsx
@@ -1,23 +1,13 @@
+import { collectLogFiles } from '../lib/fsUtils'
+
 interface Props {
   onLoad: (texts: string[], fileNames: string[]) => void
+  onWatchDir?: (handle: FileSystemDirectoryHandle) => void
   disabled: boolean
+  label?: string
 }
 
-async function collectLogFiles(dir: FileSystemDirectoryHandle): Promise<{ name: string; text: string }[]> {
-  const results: { name: string; text: string }[] = []
-  for await (const entry of dir.values()) {
-    if (entry.kind === 'file' && /\.(log|txt)$/i.test(entry.name)) {
-      const file = await (entry as FileSystemFileHandle).getFile()
-      results.push({ name: entry.name, text: await file.text() })
-    } else if (entry.kind === 'directory') {
-      const sub = await collectLogFiles(entry as FileSystemDirectoryHandle)
-      results.push(...sub)
-    }
-  }
-  return results
-}
-
-export function FilePicker({ onLoad, disabled }: Props) {
+export function FilePicker({ onLoad, onWatchDir, disabled, label }: Props) {
   async function pickFiles() {
     const handles = await window.showOpenFilePicker({
       multiple: true,
@@ -40,18 +30,24 @@ export function FilePicker({ onLoad, disabled }: Props) {
       return
     }
     onLoad(results.map((r) => r.text), results.map((r) => r.name))
+    onWatchDir?.(dirHandle)
+  }
+
+  if (label) {
+    return (
+      <div className="file-picker-inline">
+        <button onClick={pickFiles} disabled={disabled}>{label}（ファイル）</button>
+        <button onClick={pickDirectory} disabled={disabled}>{label}（フォルダ）</button>
+      </div>
+    )
   }
 
   return (
     <div className="file-picker">
       <p className="file-picker-hint">Apache アクセスログを選択してください</p>
       <div className="file-picker-buttons">
-        <button onClick={pickFiles} disabled={disabled}>
-          ファイルを選択
-        </button>
-        <button onClick={pickDirectory} disabled={disabled}>
-          フォルダを選択
-        </button>
+        <button onClick={pickFiles} disabled={disabled}>ファイルを選択</button>
+        <button onClick={pickDirectory} disabled={disabled}>フォルダを選択</button>
       </div>
     </div>
   )

--- a/app/src/hooks/useDirectoryWatch.ts
+++ b/app/src/hooks/useDirectoryWatch.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react'
+import { collectLogFiles } from '../lib/fsUtils'
+
+const POLL_INTERVAL_MS = 10_000
+
+export function useDirectoryWatch(
+  dirHandle: FileSystemDirectoryHandle | null,
+  onNewFiles: (texts: string[], names: string[]) => void,
+) {
+  const seenRef = useRef<Map<string, number>>(new Map())
+  const callbackRef = useRef(onNewFiles)
+  callbackRef.current = onNewFiles
+
+  useEffect(() => {
+    if (!dirHandle) {
+      seenRef.current.clear()
+      return
+    }
+
+    // 初回スキャン: 既存ファイルを「既読」としてマーク（再解析しない）
+    collectLogFiles(dirHandle).then((files) => {
+      files.forEach((f) => seenRef.current.set(f.name, f.lastModified))
+    })
+
+    const poll = async () => {
+      const files = await collectLogFiles(dirHandle)
+      const newFiles = files.filter((f) => {
+        const prev = seenRef.current.get(f.name)
+        return prev === undefined || prev < f.lastModified
+      })
+      if (newFiles.length > 0) {
+        newFiles.forEach((f) => seenRef.current.set(f.name, f.lastModified))
+        callbackRef.current(
+          newFiles.map((f) => f.text),
+          newFiles.map((f) => f.name),
+        )
+      }
+    }
+
+    const id = setInterval(poll, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [dirHandle])
+}

--- a/app/src/lib/fsUtils.ts
+++ b/app/src/lib/fsUtils.ts
@@ -1,0 +1,19 @@
+export interface FileEntry {
+  name: string
+  text: string
+  lastModified: number
+}
+
+export async function collectLogFiles(dir: FileSystemDirectoryHandle): Promise<FileEntry[]> {
+  const results: FileEntry[] = []
+  for await (const entry of dir.values()) {
+    if (entry.kind === 'file' && /\.(log|txt)$/i.test(entry.name)) {
+      const file = await (entry as FileSystemFileHandle).getFile()
+      results.push({ name: entry.name, text: await file.text(), lastModified: file.lastModified })
+    } else if (entry.kind === 'directory') {
+      const sub = await collectLogFiles(entry as FileSystemDirectoryHandle)
+      results.push(...sub)
+    }
+  }
+  return results
+}


### PR DESCRIPTION
## Summary

- フォルダを選択すると `FileSystemDirectoryHandle` を保持しポーリングを開始
- 10秒ごとにフォルダを再スキャンし、ファイル名 + `lastModified` で変更を検知
- 新規・更新ファイルのみ `analyze` に渡して追加解析（既存データはそのまま）
- ダッシュボードに「監視中（10秒ごと）」バッジを表示（点滅アニメーション付き）

## 新規ファイル

- `lib/fsUtils.ts` — `collectLogFiles` を共有ユーティリティとして切り出し
- `hooks/useDirectoryWatch.ts` — ポーリングロジックを封じ込めたカスタムフック

## Test plan

- [ ] フォルダを選択 → 「監視中」バッジが表示される
- [ ] フォルダにログファイルを追加 → 10秒以内に自動で解析される
- [ ] 既存ファイルの更新 → 差分のみ取り込まれる
- [ ] リセットボタン → ポーリング停止、バッジ消える

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)