### PR TITLE
style(dashboard): reduce vertical spacing for more compact layout

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -176,8 +176,8 @@ export default function App() {
   ) : null
 
   return (
-    <div className="max-w-[1200px] mx-auto px-4 py-6">
-      <header className="mb-8">
+    <div className="max-w-[1200px] mx-auto px-4 py-4">
+      <header className="mb-4">
         <h1 className="text-2xl font-bold">Log Dashboard</h1>
         <p className="text-sm text-muted-foreground mt-1">Apache access log analyzer — runs entirely in your browser</p>
         <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2">

--- a/app/src/components/RequestsChart.tsx
+++ b/app/src/components/RequestsChart.tsx
@@ -10,12 +10,12 @@ export function RequestsChart({ requestsPerHour }: Props) {
   if (requestsPerHour.length === 0) return null
 
   return (
-    <Card className="mb-4">
-      <CardHeader>
-        <CardTitle>Requests per Hour</CardTitle>
+    <Card className="mb-3 py-3 gap-2">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-sm">Requests per Hour</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={220}>
+        <ResponsiveContainer width="100%" height={160}>
           <BarChart data={requestsPerHour} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#333" vertical={false} />
             <XAxis

--- a/app/src/components/StatsCards.tsx
+++ b/app/src/components/StatsCards.tsx
@@ -18,17 +18,17 @@ interface Props {
 
 export function StatsCards({ stats }: Props) {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
       {[
         { label: 'Total Requests', value: fmt(stats.totalRequests) },
         { label: 'Unique IPs', value: fmt(stats.uniqueIps) },
         { label: 'Error Rate', value: `${stats.errorRate}%` },
         { label: 'Data Transferred', value: fmtBytes(stats.totalBytes) },
       ].map(({ label, value }) => (
-        <Card key={label}>
-          <CardContent className="pt-6">
-            <p className="text-sm text-muted-foreground mb-1">{label}</p>
-            <p className="text-2xl font-bold">{value}</p>
+        <Card key={label} className="py-0 gap-0">
+          <CardContent className="pt-3 pb-3">
+            <p className="text-xs text-muted-foreground mb-0.5">{label}</p>
+            <p className="text-xl font-bold">{value}</p>
           </CardContent>
         </Card>
       ))}

--- a/app/src/components/StatusChart.tsx
+++ b/app/src/components/StatusChart.tsx
@@ -17,12 +17,12 @@ export function StatusChart({ statusCodes }: Props) {
   const data = statusCodes.map((s) => ({ name: String(s.status), value: s.count }))
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Status Codes</CardTitle>
+    <Card className="py-3 gap-2">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-sm">Status Codes</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={220}>
+        <ResponsiveContainer width="100%" height={160}>
           <PieChart>
             <Pie
               data={data}

--- a/app/src/components/TopPaths.tsx
+++ b/app/src/components/TopPaths.tsx
@@ -14,12 +14,12 @@ export function TopPaths({ topPaths }: Props) {
   }))
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Top Paths</CardTitle>
+    <Card className="py-3 gap-2">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-sm">Top Paths</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={Math.max(180, data.length * 36)}>
+        <ResponsiveContainer width="100%" height={Math.max(160, data.length * 28)}>
           <BarChart
             data={data}
             layout="vertical"


### PR DESCRIPTION
## Summary

- Reduced container padding (py-6 → py-4) and header margin (mb-8 → mb-4)
- StatsCards: removed card-level padding (py-0 gap-0), tightened content padding, smaller value font (text-xl)
- Chart cards (RequestsChart, TopPaths, StatusChart): py-3 gap-2, CardHeader pb-0, title text-sm
- Chart heights reduced: 220 → 160px, TopPaths row height 36 → 28px

Closes #23

## Test plan

- [ ] Dashboard fits more content on screen without scrolling
- [ ] No content cut off or overlapping
- [ ] Charts remain readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)