### PR TITLE
fix: strip timezone from timestamp to prevent hour shift on reload

### DIFF
--- a/app/src/lib/duckdb.ts
+++ b/app/src/lib/duckdb.ts
@@ -109,7 +109,7 @@ export async function loadLogs(entries: LogEntry[]): Promise<void> {
     ip: e.ip,
     identity: e.identity,
     user: e.user,
-    ts: isNaN(e.timestamp.getTime()) ? null : e.timestamp.toISOString(),
+    ts: isNaN(e.timestamp.getTime()) ? null : e.timestamp.toISOString().replace('T', ' ').slice(0, 23),
     method: e.method,
     path: e.path,
     protocol: e.protocol,


### PR DESCRIPTION
## Summary

- `toISOString()` produces a `Z`-suffixed UTC string
- DuckDB `read_json_auto` auto-detects this as `TIMESTAMPTZ`
- The `::TIMESTAMP` cast then applies the session timezone, making hour values inconsistent across the Parquet round-trip
- Fix: remove the `Z` and `T` separator so the string is treated as a naive TIMESTAMP with no offset adjustment

## Test plan

- [ ] Load log files → note the number of bars in Requests per Hour
- [ ] Reload the page → bars count matches the pre-reload count

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)